### PR TITLE
Bug fix: avoiding a trailing comma in POLY line

### DIFF
--- a/antabfs.py
+++ b/antabfs.py
@@ -52,6 +52,7 @@
 # gonzalez 		      - Added flags ";setup" and "/setup" to get the current setup.
 #			      - Minor fixes.
 # gonzalez     11/08/2020     - Changed datetime.fromtimestamp() to datetime.utcfromtimestamp() to keep UTC independently of user's timezone.
+# marcote      14/09/2020     - Removes a trailing comma in poly avoiding the case of e.g. POLY=1.0, /
 #----------------------------------------------------------------------------------------------------------------------------------------------------------
 
 
@@ -1699,6 +1700,8 @@ class antabHeader:
 					else:
 						strLine = "%s,%s" % (strLine,element)
 					i = i + 1
+                                if strLine.strip()[-1] == ',':
+                                    strLine = strLine.strip()[:-1]
 				strLine += ' /\n'
 				polyLineArray[setup].append(strLine)
 	

--- a/antabfs.py
+++ b/antabfs.py
@@ -1700,8 +1700,8 @@ class antabHeader:
 					else:
 						strLine = "%s,%s" % (strLine,element)
 					i = i + 1
-                                if strLine.strip()[-1] == ',':
-                                    strLine = strLine.strip()[:-1]
+				if strLine.strip()[-1] == ',':
+					strLine = strLine.strip()[:-1]
 				strLine += ' /\n'
 				polyLineArray[setup].append(strLine)
 	


### PR DESCRIPTION
In the cases when a station only provides a nominal gain curve polynomial, the current version wrote the line
```
POLY=1.0, /
```

This breaks in several readers as a value would be expected after the comma. This fix avoids this issue and leaves the line as expected:
```
POLY=1.0 /
```

Other scenarios remain unchanged.